### PR TITLE
Adjust test execution for CI Orb

### DIFF
--- a/test/api-suite/docker-compose.yaml
+++ b/test/api-suite/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       - EXPORT_RESULTS=${EXPORT_SCRIPT:-docker/export_to_mongo.sh}
       - API_URL=${API_URL:-localhost:80/healthcheck}
     volumes:
-      - ./tests_result/:/app/results
+      - ./results/:/app/results
     network_mode: 'host'
 
 volumes:

--- a/test/api-suite/docker-compose.yaml
+++ b/test/api-suite/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       - EXPORT_RESULTS=${EXPORT_SCRIPT:-docker/export_to_mongo.sh}
       - API_URL=${API_URL:-localhost:80/healthcheck}
     volumes:
-      - ./results/:/app/results
+      - ./result/:/app/results
     network_mode: 'host'
 
 volumes:

--- a/test/api-suite/test_entrypoint.sh
+++ b/test/api-suite/test_entrypoint.sh
@@ -1,0 +1,5 @@
+## Required Global variables used to execute test harness 
+## RESULT_NAME <- determines where test result is stored. 
+## API_URL <- used to detemine base URL of tested API
+chmod u+x docker/entrypoint.sh 
+docker-compose up --build gherkin-test-report


### PR DESCRIPTION
@taylordowns2000 This PR contains changes needed by the orb. I've added test_entrypoint.sh and adjusted mount point for the test result. Currently CI still fails due to unset env variables. This variables are related to reporting server API which is not yet deployed. 
